### PR TITLE
Add the ability to custom Cookie-Domain

### DIFF
--- a/admin/cli-admin-page.php
+++ b/admin/cli-admin-page.php
@@ -305,6 +305,17 @@ function cookielawinfo_print_admin_page() {
 								
 							</td>
 						</tr>
+
+						<tr valign="top">
+							<th scope="row"><label for="cookie_domain">Cookie Domain</label></th>
+							<td>
+								<input type="text" name="cookie_domain_field" value="<?php echo $the_options['cookie_domain'] ?>" />
+								<br/>
+								<small>You can restrict the cookie to a single sub-domain, domain etc.<br /> Ex: this-one.domain.com, or domain.com etc.
+								</small>
+							</td>
+						</tr>
+
 					</table>
 					
 				</dd>

--- a/admin/cli-admin.php
+++ b/admin/cli-admin.php
@@ -49,6 +49,7 @@ function cookielawinfo_get_default_settings() {
 		'button_2_as_button'			=> false,
 		'button_2_button_colour' 		=> '#333',
 		'button_2_button_size' 			=> 'medium',
+		'cookie_domain'					=> parse_url(get_site_url(), PHP_URL_HOST), 
 		'font_family' 					=> 'inherit', // Pick the family, not the easy name (see helper function below)
 		'header_fix'                    => false,
 		'is_on' 						=> true,

--- a/js/cookielawinfo.js
+++ b/js/cookielawinfo.js
@@ -8,7 +8,14 @@ function cli_show_cookiebar(p) {
 				var expires = "; expires="+date.toGMTString();
 			}
 			else var expires = "";
-			document.cookie = name+"="+value+expires+"; path=/";
+
+			var cookie_domain = '';
+			console.log('----', settings); 
+			if (settings.cookie_domain && settings.cookie_domain.length) {
+				cookie_domain = '; domain=' + settings.cookie_domain;
+			}
+
+			document.cookie = name+"=" + value + expires + cookie_domain + "; path=/";
 		},
 		read: function(name) {
 			var nameEQ = name + "=";

--- a/php/functions.php
+++ b/php/functions.php
@@ -44,6 +44,7 @@ function cookielawinfo_get_json_settings() {
 		'button_2_button_hover'			=> (cookielawinfo_su_hex_shift( $settings['button_2_button_colour'], 'down', 20 )),
 		'button_2_link_colour'			=> $settings['button_2_link_colour'],
 		'button_2_as_button'			=> $settings['button_2_as_button'],
+		'cookie_domain'				=> $settings['cookie_domain'],
 		'font_family'					=> $settings['font_family'],
 		'header_fix'                    => $settings['header_fix'],
 		'notify_animate_hide'			=> $settings['notify_animate_hide'],


### PR DESCRIPTION
Your plug-in is nice but it would be better if the cookie "viewed_cookie_policy" could be configure on a specific sub-domain name, or on the full domain (*.mydomain.com) or whatever... 
For example, two wordpresses under the same domain : blog.mydomain.com and www.mydomain.com. if I "Accept" the "cookie law info bar" in the first domain, it's not necessary to show it again on the second one. It means : several sub-domains but 1 unique cookie bar ! 
I did it for you !

Let's review it.
